### PR TITLE
include <unistd.h>

### DIFF
--- a/ping-draw.c
+++ b/ping-draw.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include <err.h>


### PR DESCRIPTION
...to fix compilation error
```
ping-draw.c: In function ‘main’:
ping-draw.c:188:14: warning: implicit declaration of function ‘getopt’ [-Wimplicit-function-declaration]
  while ((c = getopt(argc, argv, "x:y:f:h")) != -1) {
              ^~~~~~
ping-draw.c:191:20: error: ‘optarg’ undeclared (first use in this function)
    offset_x = atoi(optarg);
                    ^~~~~~
```